### PR TITLE
Added 'swing gate' to whitelist on oma-bicycle.lua

### DIFF
--- a/oma-bicycle.lua
+++ b/oma-bicycle.lua
@@ -51,7 +51,8 @@ local profile = {
     'sally_port',
     'gate',
     'no',
-    'block','kerb'
+    'block','kerb',
+    'swing gate'
   },
 
   access_tag_whitelist = Set {


### PR DESCRIPTION
On many bicycle route are swing gate that protect route for unauthorized vehicle entry in forests but bicycle are allowed.